### PR TITLE
Fix build errors and runtime issues for clean starting point

### DIFF
--- a/Domain/Interfaces/IBypassService.cs
+++ b/Domain/Interfaces/IBypassService.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Domain.Interfaces;
+﻿namespace Domain.Interfaces;
 
 public interface IBypassService
 {

--- a/Domain/Models/ProxyOptions.cs
+++ b/Domain/Models/ProxyOptions.cs
@@ -18,8 +18,6 @@ public sealed class ProxyOptions
 
     public string CachePath { get; set; } = "rating_cache.db";
 
-    public int LogBufferSize { get; set; } = 500;
-
     /// <summary>
     /// Maximum number of concurrent TMDB lookup workers.
     /// Prevents the background queue from flooding the proxy under heavy load.

--- a/ReverseProxy/AppBuilder.cs
+++ b/ReverseProxy/AppBuilder.cs
@@ -1,5 +1,6 @@
 using Domain;
 using Domain.Interfaces;
+using Domain.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,6 +38,10 @@ public static class AppBuilder
         _ = builder.Services.AddSingleton<RatingCache>();
         _ = builder.Services.AddSingleton<IRatingCache>(sp => sp.GetRequiredService<RatingCache>());
 
+        // Bypass toggle — singleton shared with WebAdmin via explicit service extraction
+        _ = builder.Services.AddSingleton<BypassService>();
+        _ = builder.Services.AddSingleton<IBypassService>(sp => sp.GetRequiredService<BypassService>());
+
         // TMDB helpers
         _ = builder.Services.AddSingleton<TmdbService>();
 
@@ -54,17 +59,6 @@ public static class AppBuilder
         _ = builder.Services
             .AddReverseProxy()
             .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
-
-        // ---------------------------------------------------------------------------
-        // Logging
-        // ---------------------------------------------------------------------------
-        //_ = builder.Logging.ClearProviders();
-        //_ = builder.Logging.AddSimpleConsole(o =>
-        //{
-        //    o.SingleLine      = true;
-        //    o.TimestampFormat = "HH:mm:ss ";
-        //});
-        //_ = builder.Logging.SetMinimumLevel(LogLevel.Trace);
 
         var app = builder.Build();
 

--- a/ReverseProxy/RatingCache.cs
+++ b/ReverseProxy/RatingCache.cs
@@ -32,7 +32,7 @@ public sealed class RatingCache : IRatingCache
         int IsManualOverride,      // SQLite has no bool; 0/1
         long? LastTmdbAttemptUnix
     )
-    { public CacheRow() : this(default, default, default, default, default, default) { } }
+    { public CacheRow() : this(string.Empty, string.Empty, null, null, 0, null) { } }
 
     // -------------------------------------------------------------------------
     // Fields
@@ -116,7 +116,7 @@ public sealed class RatingCache : IRatingCache
 
     public IReadOnlyList<CacheEntry> GetAllEntries()
     {
-        return _map.Values
+        return _map.Values.ToList()
             .Select(row => new CacheEntry(
                 JellyfinId:      row.JellyfinId,
                 ItemName:        row.ItemName,

--- a/WebAdmin/Program.cs
+++ b/WebAdmin/Program.cs
@@ -23,10 +23,11 @@ public class Program
         _ = builder.Services.AddRazorComponents()
                             .AddInteractiveServerComponents();
 
-        // Share the IRatingCache singleton that was registered inside the
-        // reverse proxy's DI container so the WebAdmin UI can read and write it.
-        var sharedCache = reverseProxyApp.Services.GetRequiredService<IRatingCache>();
+        // Share singletons from the reverse proxy's DI container with WebAdmin
+        var sharedCache  = reverseProxyApp.Services.GetRequiredService<IRatingCache>();
+        var sharedBypass = reverseProxyApp.Services.GetRequiredService<IBypassService>();
         _ = builder.Services.AddSingleton(sharedCache);
+        _ = builder.Services.AddSingleton(sharedBypass);
 
         _ = builder.Logging.ClearProviders();
         _ = builder.Logging.AddSimpleConsole(o =>
@@ -40,12 +41,7 @@ public class Program
 
         // HTTP pipeline
         if (!webAdminApp.Environment.IsDevelopment())
-        {
             _ = webAdminApp.UseExceptionHandler("/Error");
-            _ = webAdminApp.UseHsts();
-        }
-
-        _ = webAdminApp.UseHttpsRedirection();
         _ = webAdminApp.UseAntiforgery();
         _ = webAdminApp.MapStaticAssets();
         _ = webAdminApp.MapRazorComponents<App>()

--- a/WebAdmin/appsettings.json
+++ b/WebAdmin/appsettings.json
@@ -20,9 +20,9 @@
   //   TMDB_QUEUE_CAPACITY=500
   //   CACHE_PATH=/data/rating_cache.db
   // ---------------------------------------------------------------------------
-  "JellyfinUrl": "secret",
+  "JellyfinUrl": "http://127.0.0.1:8096",
   "MaxRating": "PG",
-  "TmdbApiKey": "secret",
+  "TmdbApiKey": "",
   "TmdbRegion": "US",
   "TmdbRetryHours": 24,
 
@@ -52,7 +52,7 @@
       "jellyfin-cluster": {
         "Destinations": {
           "primary": {
-            "Address": "secret"
+            "Address": "http://127.0.0.1:8096"
           }
         }
       }


### PR DESCRIPTION
- Add missing `using Domain.Models` to AppBuilder.cs (caused CS0246 compile errors)
- Register BypassService/IBypassService in DI container (was injected by middleware but never registered)
- Share IBypassService singleton from proxy DI into WebAdmin DI (bypass API endpoints couldn't resolve it)
- Fix CacheRow parameterless constructor to avoid CS8625 null literal warnings
- Snapshot ConcurrentDictionary before LINQ ordering in GetAllEntries()
- Remove unused LogBufferSize property from ProxyOptions
- Remove spurious unused usings from IBypassService interface
- Remove dead commented-out logging block from AppBuilder
- Remove HTTPS redirect/HSTS (app is HTTP-only; no HTTPS port configured)
- Reset appsettings.json to sensible defaults (was "secret" which caused YARP 500 on every request)